### PR TITLE
Fix Next.js 15 params awaiting in profile API route

### DIFF
--- a/src/app/api/profile/[userId]/route.ts
+++ b/src/app/api/profile/[userId]/route.ts
@@ -108,7 +108,7 @@ export async function GET(
   request: Request,
   { params }: { params: { userId: string } }
 ) {
-  const { userId } = params;
+  const { userId } = await params;
 
   if (!userId) {
     return NextResponse.json({ error: 'Missing userId' }, { status: 400 });


### PR DESCRIPTION
## Problem
The application was throwing a Next.js error:
```
Error: Route "/api/profile/[userId]" used `params.userId`. `params` should be awaited before using its properties.
```

This error was preventing the profile API from working correctly and likely causing the "Select & Verify" button to be non-functional.

## Root Cause
Next.js 15 introduced a breaking change where route parameters (`params`) are now returned as a Promise and must be awaited before accessing their properties.

## Solution
Changed line 111 in `src/app/api/profile/[userId]/route.ts`:
- **Before:** `const { userId } = params;`
- **After:** `const { userId } = await params;`

## Impact
- ✅ Fixes the API 500 error in the profile route
- ✅ Should restore functionality to the "Select & Verify" button
- ✅ Complies with Next.js 15 requirements
- ✅ No other API routes were affected (verified all routes)

## Testing
After merging, please test:
1. The profile API endpoint works without errors
2. The "Select & Verify" button is now clickable and functional

## Additional Notes
- The function was already marked as `async`, so no signature changes were needed
- Other API routes using `searchParams` from URL objects don't require this change
- Only dynamic route parameters need to be awaited