### PR TITLE
Fix: SmartSuggest not appearing on subsequent display name searches

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -272,8 +272,9 @@ function VerifierTool() {
   };
 
   const handleSelectCandidate = async (username: string) => {
-    await handleSubmit({ preventDefault: () => {} } as React.FormEvent, [username], false);
-};
+    setInput(username);
+    await handleSubmit({ preventDefault: () => {} } as React.FormEvent, [], false);
+  };
 
   const handleInspectCandidate = (userId: number) => {
     setSelectedUserId(userId.toString());


### PR DESCRIPTION
## Problem
After clicking "Select & Verify" on a SmartSuggest candidate, subsequent display name searches would not show suggestions even when matches were found.

**User Flow:**
1. Search for display name (e.g., "richard gobbler") → Suggestions appear ✅
2. Click "Select & Verify" → Verification works ✅
3. Search again for display name (e.g., "john doe") → Suggestions DON'T appear ❌

## Root Cause
The `handleSelectCandidate` function was treating the single username verification as a batch operation:

```javascript
const handleSelectCandidate = async (username: string) => {
    await handleSubmit({ preventDefault: () => {} } as React.FormEvent, [username], false);
};
```

By passing `[username]` as the `batchInputs` parameter, it triggered:
- `setIsBatchMode(batchInputs.length > 0)` → `setIsBatchMode(true)`

This caused the SmartSuggest component to not render on subsequent searches because of the rendering condition:
```jsx
{!isBatchMode && scoredCandidates.length > 0 && (
  <SmartSuggest ... />
)}
```

Even though `scoredCandidates` was being populated correctly, `isBatchMode` remained `true`, blocking the component from displaying.

## Solution
Modified `handleSelectCandidate` to:
1. Set the input field directly with the selected username
2. Call `handleSubmit` with an empty batch array to keep `isBatchMode = false`

```javascript
const handleSelectCandidate = async (username: string) => {
    setInput(username);
    await handleSubmit({ preventDefault: () => {} } as React.FormEvent, [], false);
};
```

This ensures:
- Each search is treated independently
- SmartSuggest appears every time display name searches return suggestions
- The suggestion logic works in a loop without state interference

## Testing
After this fix:
1. Search for display name → Suggestions appear ✅
2. Click "Select & Verify" → Verification works ✅
3. Search again for display name → Suggestions appear again ✅
4. Repeat as many times as needed → Always works ✅